### PR TITLE
added deprecation essage in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![Standard Test](https://github.com/gobuffalo/mw-csrf/actions/workflows/standard-go-test.yml/badge.svg)](https://github.com/gobuffalo/mw-csrf/actions/workflows/standard-go-test.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/gobuffalo/mw-csrf.svg)](https://pkg.go.dev/github.com/gobuffalo/mw-csrf)
 
+NOTE: v1.0.2 will be the last version of this module and it will be deprecated.
+Use <https://github.com/gobuffalo/middleware> instead.
+
 ### Requirements
 
 * Go 1.16+ but 1.17 and 1.18 are officially supported


### PR DESCRIPTION
### What is being done in this PR?

* updated module dependencies up-to-date, as of 2023-02-12
* added a deprecation message in the README.md

This will the last release of mw-csrf and it will be replaced with github.com/gobuffalo/middleware/csrf soon.